### PR TITLE
ATProto Publishing Stub

### DIFF
--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -7,9 +7,18 @@
 -   Basic browser extension scaffold (Manifest V3)
 -   Popup interface with status and verification button
 -   Mock Holonym verification flow
+-   **ATProto (Bluesky) post simulation in Mock Mode**
 -   TypeScript support for safer development
 -   Uses [Bun](https://bun.sh) as the package manager and runtime
 -   Future: Bluesky badge display, AT Protocol publishing, test mode, packaging
+
+## ATProto Simulation (Developer Demo)
+
+You can simulate publishing a verification post to the AT Protocol (e.g. Bluesky) while in Mock Verification Mode.
+
+**Note:**
+
+-   No real data is posted to Bluesky or the AT Protocol.
 
 ## Development Setup
 

--- a/apps/extension/bun.lock
+++ b/apps/extension/bun.lock
@@ -3,6 +3,7 @@
   "workspaces": {
     "": {
       "dependencies": {
+        "@atproto/api": "^0.15.19",
         "webextension-polyfill": "^0.12.0",
       },
       "devDependencies": {
@@ -15,6 +16,16 @@
     },
   },
   "packages": {
+    "@atproto/api": ["@atproto/api@0.15.19", "", { "dependencies": { "@atproto/common-web": "^0.4.2", "@atproto/lexicon": "^0.4.11", "@atproto/syntax": "^0.4.0", "@atproto/xrpc": "^0.7.0", "await-lock": "^2.2.2", "multiformats": "^9.9.0", "tlds": "^1.234.0", "zod": "^3.23.8" } }, "sha512-+oFw+RjUSZX9zG49yNUpPPPdofCZ/RTtTzVf55Ab1gaskuHQ0ONoaTRK9GRx23XP7u7ipmTDayvJldbNLOkdUw=="],
+
+    "@atproto/common-web": ["@atproto/common-web@0.4.2", "", { "dependencies": { "graphemer": "^1.4.0", "multiformats": "^9.9.0", "uint8arrays": "3.0.0", "zod": "^3.23.8" } }, "sha512-vrXwGNoFGogodjQvJDxAeP3QbGtawgZute2ed1XdRO0wMixLk3qewtikZm06H259QDJVu6voKC5mubml+WgQUw=="],
+
+    "@atproto/lexicon": ["@atproto/lexicon@0.4.11", "", { "dependencies": { "@atproto/common-web": "^0.4.2", "@atproto/syntax": "^0.4.0", "iso-datestring-validator": "^2.2.2", "multiformats": "^9.9.0", "zod": "^3.23.8" } }, "sha512-btefdnvNz2Ao2I+qbmj0F06HC8IlrM/IBz6qOBS50r0S6uDf5tOO+Mv2tSVdimFkdzyDdLtBI1sV36ONxz2cOw=="],
+
+    "@atproto/syntax": ["@atproto/syntax@0.4.0", "", {}, "sha512-b9y5ceHS8YKOfP3mdKmwAx5yVj9294UN7FG2XzP6V5aKUdFazEYRnR9m5n5ZQFKa3GNvz7de9guZCJ/sUTcOAA=="],
+
+    "@atproto/xrpc": ["@atproto/xrpc@0.7.0", "", { "dependencies": { "@atproto/lexicon": "^0.4.11", "zod": "^3.23.8" } }, "sha512-SfhP9dGx2qclaScFDb58Jnrmim5nk4geZXCqg6sB0I/KZhZEkr9iIx1hLCp+sxkIfEsmEJjeWO4B0rjUIJW5cw=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
@@ -226,6 +237,8 @@
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
     "atomically": ["atomically@2.0.3", "", { "dependencies": { "stubborn-fs": "^1.2.5", "when-exit": "^2.1.1" } }, "sha512-kU6FmrwZ3Lx7/7y3hPS5QnbJfaohcIul5fGqf7ok+4KklIEk9tJ0C2IQPdacSbVUWv6zVHXEBWoWd6NrVMT7Cw=="],
+
+    "await-lock": ["await-lock@2.2.2", "", {}, "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
@@ -483,6 +496,8 @@
 
     "isexe": ["isexe@1.1.2", "", {}, "sha512-d2eJzK691yZwPHcv1LbeAOa91yMJ9QmfTgSO1oXB65ezVhXQsxBac2vEB4bMVms9cGzaA99n6V2viHMq82VLDw=="],
 
+    "iso-datestring-validator": ["iso-datestring-validator@2.2.2", "", {}, "sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA=="],
+
     "jose": ["jose@5.9.6", "", {}, "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
@@ -532,6 +547,8 @@
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "multiformats": ["multiformats@9.9.0", "", {}, "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="],
 
     "multimatch": ["multimatch@6.0.0", "", { "dependencies": { "@types/minimatch": "^3.0.5", "array-differ": "^4.0.0", "array-union": "^3.0.1", "minimatch": "^3.0.4" } }, "sha512-I7tSVxHGPlmPN/enE3mS1aOSo6bWBfls+3HmuEeCUBCE7gWnm3cBXCBkpurzFjVRwC6Kld8lLaZ1Iv5vOcjvcQ=="],
 
@@ -695,6 +712,8 @@
 
     "tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
 
+    "tlds": ["tlds@1.259.0", "", { "bin": { "tlds": "bin.js" } }, "sha512-AldGGlDP0PNgwppe2quAvuBl18UcjuNtOnDuUkqhd6ipPqrYYBt3aTxK1QTsBVknk97lS2JcafWMghjGWFtunw=="],
+
     "tmp": ["tmp@0.2.3", "", {}, "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
@@ -704,6 +723,8 @@
     "typedarray": ["typedarray@0.0.6", "", {}, "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="],
 
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "uint8arrays": ["uint8arrays@3.0.0", "", { "dependencies": { "multiformats": "^9.4.2" } }, "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA=="],
 
     "undici-types": ["undici-types@7.8.0", "", {}, "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="],
 
@@ -764,6 +785,8 @@
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "zip-dir": ["zip-dir@2.0.0", "", { "dependencies": { "async": "^3.2.0", "jszip": "^3.2.2" } }, "sha512-uhlsJZWz26FLYXOD6WVuq+fIcZ3aBPGo/cFdiLlv3KNwpa52IF3ISV8fLhQLiqVu5No3VhlqlgthN6gehil1Dg=="],
+
+    "zod": ["zod@3.25.67", "", {}, "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -14,6 +14,7 @@
     "bun": ">=1.0.0"
   },
   "dependencies": {
+    "@atproto/api": "^0.15.19",
     "webextension-polyfill": "^0.12.0"
   },
   "devDependencies": {

--- a/apps/extension/popup/api/atproto.ts
+++ b/apps/extension/popup/api/atproto.ts
@@ -1,0 +1,37 @@
+import type { MockVerificationResult } from '../mocks/mockHolonym';
+
+/**
+ * Simulates publishing a verification post to the AT Protocol (Bluesky).
+ * Uses a dummy proof object consistent with MockVerificationResult.
+ */
+export async function publishVerificationPost(
+    userHandle: string,
+    proof: MockVerificationResult
+) {
+    // Simulated post object
+    return {
+        handle: userHandle,
+        post: {
+            text: `I just verified as "${proof.badge}" using Holonym`,
+            proof,
+            createdAt: new Date().toISOString()
+        },
+        simulated: true
+    };
+}
+
+export function getDummyProof(): MockVerificationResult {
+    const badgeStrings = [
+        'Identity Verified via Holonym',
+        'Verified Person',
+        'Authenticated by ZK Proof'
+    ];
+    const randomIndex = Math.floor(Math.random() * badgeStrings.length);
+    const randomProofId = Math.random().toString(36).substring(2, 15);
+    return {
+        verified: true,
+        timestamp: new Date().toISOString(),
+        proof: `mock-zk-proof-${randomProofId}`,
+        badge: badgeStrings[randomIndex]
+    };
+}

--- a/apps/extension/popup/popup.css
+++ b/apps/extension/popup/popup.css
@@ -182,3 +182,79 @@ button:disabled {
   stroke: hsl(330, 15%, 40%) !important;
   opacity: 0.7;
 }
+
+.button-group {
+  margin-top: 10px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.button-divider {
+  margin: 12px 0 20px 0;
+  border-top: 1px solid var(--border-color);
+  width: 100%;
+}
+
+.button-label {
+  font-size: 0.92em;
+  color: var(--text-color-secondary);
+  margin-bottom: 4px;
+  text-align: left;
+  padding-left: 2px;
+}
+
+#atprotoBtn {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.atproto-result-card {
+  background: #fff;
+  border-radius: 1rem;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+  padding: 1.2em 1.2em;
+  margin-top: 0.5em;
+  text-align: left;
+  border: 1px solid #eee;
+}
+
+.atproto-result-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  margin-bottom: 1em;
+}
+
+.atproto-result-check {
+  color: #3bb273;
+  font-size: 1.3em;
+}
+
+.atproto-result-title {
+  font-weight: 600;
+  font-size: 1.08em;
+}
+
+.atproto-result-field {
+  margin-bottom: 0.7em;
+}
+
+.atproto-result-badge {
+  color: #7c3aed;
+}
+
+.atproto-result-proof {
+  color: #444;
+}
+
+.atproto-result-timestamp {
+  font-size: 0.97em;
+  color: #222;
+}
+
+.atproto-status {
+  margin-top: 10px;
+  font-size: 0.95em;
+}

--- a/apps/extension/popup/popup.css
+++ b/apps/extension/popup/popup.css
@@ -258,3 +258,8 @@ button:disabled {
   margin-top: 10px;
   font-size: 0.95em;
 }
+
+.atproto-status-error {
+  color: #b00;
+  font-weight: 500;
+}

--- a/apps/extension/popup/popup.html
+++ b/apps/extension/popup/popup.html
@@ -20,6 +20,11 @@
             </div>
 
             <button id="verifyBtn">Verify with Holonym</button>
+            <div class="button-group">
+                <div class="button-divider"></div>
+                <button id="atprotoBtn">Simulate ATProto Post</button>
+            </div>
+            <div id="atproto-status" class="atproto-status"></div>
             <label class="toggle-container">
                 <span class="toggle-label">Mock Verification Mode</span>
                 <input type="checkbox" id="mockToggle" />

--- a/apps/extension/popup/popup.ts
+++ b/apps/extension/popup/popup.ts
@@ -4,6 +4,7 @@ import {
     MockVerificationResult
 } from './mocks/mockHolonym';
 import { icons } from './utils/icons';
+import { publishVerificationPost, getDummyProof } from './api/atproto';
 
 document.addEventListener('DOMContentLoaded', () => {
     const statusTextEl = document.getElementById(
@@ -16,6 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const mockToggle = document.getElementById(
         'mockToggle'
     ) as HTMLInputElement;
+    const atprotoBtn = document.getElementById('atprotoBtn');
 
     type VerificationState = 'unverified' | 'verifying' | 'verified';
     interface StatusConfig {
@@ -123,4 +125,43 @@ document.addEventListener('DOMContentLoaded', () => {
             handleVerification(getMockVerificationResult);
         }
     });
+
+    if (atprotoBtn) {
+        atprotoBtn.addEventListener('click', handleAtprotoVerification);
+    }
 });
+
+async function handleAtprotoVerification() {
+    const atprotoStatusEl = document.getElementById(
+        'atproto-status'
+    ) as HTMLDivElement;
+    const { mockMode } = await browser.storage.local.get(['mockMode']);
+    if (!mockMode) {
+        atprotoStatusEl.textContent =
+            'ATProto simulation is only available in Mock Verification Mode.';
+        return;
+    }
+    const userHandle = 'user.bsky.social'; // Placeholder
+    const dummyProof = getDummyProof();
+    const result = await publishVerificationPost(userHandle, dummyProof);
+
+    console.log('[ATProto] Simulated post result:', result);
+
+    atprotoStatusEl.innerHTML = `
+      <div class="atproto-result-card">
+        <div class="atproto-result-header">
+          <span class="atproto-result-check">&#10003;</span>
+          <span class="atproto-result-title">Simulated ATProto Post Created</span>
+        </div>
+        <div class="atproto-result-field"><strong>Badge:</strong> <span class="atproto-result-badge">${
+            result.post.proof.badge
+        }</span></div>
+        <div class="atproto-result-field"><strong>Proof:</strong> <span class="atproto-result-proof">${
+            result.post.proof.proof
+        }</span></div>
+        <div class="atproto-result-timestamp"><strong>Timestamp:</strong> ${new Date(
+            result.post.proof.timestamp
+        ).toLocaleString()}</div>
+      </div>
+    `;
+}

--- a/apps/extension/popup/popup.ts
+++ b/apps/extension/popup/popup.ts
@@ -6,7 +6,7 @@ import {
 import { icons } from './utils/icons';
 import { publishVerificationPost, getDummyProof } from './api/atproto';
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
     const statusTextEl = document.getElementById(
         'status-text'
     ) as HTMLSpanElement;
@@ -17,7 +17,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const mockToggle = document.getElementById(
         'mockToggle'
     ) as HTMLInputElement;
-    const atprotoBtn = document.getElementById('atprotoBtn');
 
     type VerificationState = 'unverified' | 'verifying' | 'verified';
     interface StatusConfig {
@@ -28,10 +27,6 @@ document.addEventListener('DOMContentLoaded', () => {
         btnDisabled: boolean;
     }
 
-    /**
-     * Updates the UI to reflect a specific state (unverified, verifying, verified).
-     * @param {'unverified' | 'verifying' | 'verified'} state - The state to display.
-     */
     const setStatus = (state: VerificationState) => {
         statusTextEl.classList.remove('verified', 'unverified', 'verifying');
         statusIconEl.classList.remove('verified', 'unverified', 'verifying');
@@ -99,69 +94,102 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
 
-    /**
-     * Handles the verification process (mock or real).
-     * @param verificationFn - Function to generate the verification result.
-     */
-    function handleVerification(verificationFn: () => MockVerificationResult) {
-        setTimeout(() => {
-            const verificationResult = verificationFn();
-            browser.storage.local
-                .set({ verification: verificationResult })
-                .then(() => {
-                    setStatus('verified');
-                });
-        }, 2000);
-    }
-
-    button.addEventListener('click', async () => {
-        setStatus('verifying');
-        const { mockMode } = await browser.storage.local.get(['mockMode']);
-
-        if (mockMode) {
-            handleVerification(getMockVerificationResult);
-        } else {
-            // TODO: Replace getMockVerificationResult with real verification function
-            handleVerification(getMockVerificationResult);
+    function attachSimulateListener() {
+        const atprotoBtn = document.getElementById(
+            'atprotoBtn'
+        ) as HTMLButtonElement;
+        if (atprotoBtn) {
+            atprotoBtn.onclick = async () => {
+                const atprotoStatusEl = document.getElementById(
+                    'atproto-status'
+                ) as HTMLDivElement;
+                const { verification } = await browser.storage.local.get([
+                    'verification'
+                ]);
+                const isVerified =
+                    verification &&
+                    typeof verification === 'object' &&
+                    'verified' in verification &&
+                    verification.verified;
+                const { mockMode } = await browser.storage.local.get([
+                    'mockMode'
+                ]);
+                if (!isVerified) {
+                    atprotoStatusEl.innerHTML =
+                        '<div class="atproto-status-error">You must be verified before you can simulate an ATProto post.</div>';
+                    return;
+                }
+                if (!mockMode) {
+                    atprotoStatusEl.innerHTML =
+                        '<div class="atproto-status-error">ATProto simulation is only available in Mock Verification Mode.</div>';
+                    return;
+                }
+                const userHandle = 'user.bsky.social'; // Placeholder
+                const result = await publishVerificationPost(
+                    userHandle,
+                    verification as MockVerificationResult
+                );
+                atprotoStatusEl.innerHTML = `
+                  <div class="atproto-result-card">
+                    <div class="atproto-result-header">
+                      <span class="atproto-result-check">&#10003;</span>
+                      <span class="atproto-result-title">Simulated ATProto Post Created</span>
+                    </div>
+                    <div class="atproto-result-field"><strong>Badge:</strong> <span class="atproto-result-badge">${
+                        result.post.proof.badge
+                    }</span></div>
+                    <div class="atproto-result-field"><strong>Proof:</strong> <span class="atproto-result-proof">${
+                        result.post.proof.proof
+                    }</span></div>
+                    <div class="atproto-result-timestamp"><strong>Timestamp:</strong> ${new Date(
+                        result.post.proof.timestamp
+                    ).toLocaleString()}</div>
+                  </div>
+                `;
+            };
         }
-    });
-
-    if (atprotoBtn) {
-        atprotoBtn.addEventListener('click', handleAtprotoVerification);
     }
+
+    // Add event listener for the verification button
+    if (button) {
+        button.addEventListener('click', async () => {
+            setStatus('verifying');
+            setTimeout(async () => {
+                const verificationResult = getMockVerificationResult();
+                await browser.storage.local.set({
+                    verification: verificationResult
+                });
+                setStatus('verified');
+                attachSimulateListener();
+            }, 1500);
+        });
+    }
+
+    // Enable/disable simulate button and show/hide error message
+    async function updateAtprotoButtonState() {
+        const atprotoBtn = document.getElementById(
+            'atprotoBtn'
+        ) as HTMLButtonElement;
+        const atprotoStatusEl = document.getElementById(
+            'atproto-status'
+        ) as HTMLDivElement;
+        const { verification } = await browser.storage.local.get([
+            'verification'
+        ]);
+        const isVerified =
+            verification &&
+            typeof verification === 'object' &&
+            'verified' in verification &&
+            verification.verified;
+        atprotoBtn.disabled = !isVerified;
+        if (!isVerified) {
+            atprotoStatusEl.innerHTML =
+                '<div class="atproto-status-error">You must be verified before you can simulate an ATProto post.</div>';
+        } else {
+            atprotoStatusEl.innerHTML = '';
+        }
+    }
+
+    await updateAtprotoButtonState();
+    attachSimulateListener();
 });
-
-async function handleAtprotoVerification() {
-    const atprotoStatusEl = document.getElementById(
-        'atproto-status'
-    ) as HTMLDivElement;
-    const { mockMode } = await browser.storage.local.get(['mockMode']);
-    if (!mockMode) {
-        atprotoStatusEl.textContent =
-            'ATProto simulation is only available in Mock Verification Mode.';
-        return;
-    }
-    const userHandle = 'user.bsky.social'; // Placeholder
-    const dummyProof = getDummyProof();
-    const result = await publishVerificationPost(userHandle, dummyProof);
-
-    console.log('[ATProto] Simulated post result:', result);
-
-    atprotoStatusEl.innerHTML = `
-      <div class="atproto-result-card">
-        <div class="atproto-result-header">
-          <span class="atproto-result-check">&#10003;</span>
-          <span class="atproto-result-title">Simulated ATProto Post Created</span>
-        </div>
-        <div class="atproto-result-field"><strong>Badge:</strong> <span class="atproto-result-badge">${
-            result.post.proof.badge
-        }</span></div>
-        <div class="atproto-result-field"><strong>Proof:</strong> <span class="atproto-result-proof">${
-            result.post.proof.proof
-        }</span></div>
-        <div class="atproto-result-timestamp"><strong>Timestamp:</strong> ${new Date(
-            result.post.proof.timestamp
-        ).toLocaleString()}</div>
-      </div>
-    `;
-}

--- a/apps/extension/popup/popup.ts
+++ b/apps/extension/popup/popup.ts
@@ -94,6 +94,18 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
         });
 
+    // Utility function to check if a user is verified
+    function isUserVerified(
+        verification: MockVerificationResult | undefined
+    ): boolean {
+        return (
+            !!verification &&
+            typeof verification === 'object' &&
+            'verified' in verification &&
+            verification.verified
+        );
+    }
+
     function attachSimulateListener() {
         const atprotoBtn = document.getElementById(
             'atprotoBtn'
@@ -106,11 +118,9 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const { verification } = await browser.storage.local.get([
                     'verification'
                 ]);
-                const isVerified =
-                    verification &&
-                    typeof verification === 'object' &&
-                    'verified' in verification &&
-                    verification.verified;
+                const isVerified = isUserVerified(
+                    verification as MockVerificationResult | undefined
+                );
                 const { mockMode } = await browser.storage.local.get([
                     'mockMode'
                 ]);
@@ -150,21 +160,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
     }
 
-    // Add event listener for the verification button
-    if (button) {
-        button.addEventListener('click', async () => {
-            setStatus('verifying');
-            setTimeout(async () => {
-                const verificationResult = getMockVerificationResult();
-                await browser.storage.local.set({
-                    verification: verificationResult
-                });
-                setStatus('verified');
-                attachSimulateListener();
-            }, 1500);
-        });
-    }
-
     // Enable/disable simulate button and show/hide error message
     async function updateAtprotoButtonState() {
         const atprotoBtn = document.getElementById(
@@ -176,11 +171,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         const { verification } = await browser.storage.local.get([
             'verification'
         ]);
-        const isVerified =
-            verification &&
-            typeof verification === 'object' &&
-            'verified' in verification &&
-            verification.verified;
+        const isVerified = isUserVerified(
+            verification as MockVerificationResult | undefined
+        );
         atprotoBtn.disabled = !isVerified;
         if (!isVerified) {
             atprotoStatusEl.innerHTML =
@@ -188,6 +181,21 @@ document.addEventListener('DOMContentLoaded', async () => {
         } else {
             atprotoStatusEl.innerHTML = '';
         }
+    }
+
+    if (button) {
+        button.addEventListener('click', async () => {
+            setStatus('verifying');
+            setTimeout(async () => {
+                const verificationResult = getMockVerificationResult();
+                await browser.storage.local.set({
+                    verification: verificationResult
+                });
+                setStatus('verified');
+                await updateAtprotoButtonState();
+                attachSimulateListener();
+            }, 1500);
+        });
     }
 
     await updateAtprotoButtonState();


### PR DESCRIPTION
This pull request introduces the ATProto (Bluesky) post simulation feature and improves the popup UI.

This work closes [#18](https://github.com/elephant-dog-org/privid/issues/18) and [#20](https://github.com/elephant-dog-org/privid/issues/20).

---

### What's New?

#### ATProto Simulation
- **Simulate ATProto Post:**  
  - A new "Simulate ATProto Post" button is available in the popup, below a visual divider.
  - When Mock Verification Mode is enabled and the user is verified, clicking this button displays a visually styled card simulating a post to the AT Protocol (Bluesky) using the actual stored verification data (badge, proof, timestamp).
  - The simulation is only available in Mock Mode and when the user is verified; otherwise, a clear error message is shown.

#### UI/UX Improvements
- **Popup Layout:**  
  - The popup UI is more user-friendly, with clear separation between primary actions and developer/demo features.
  - All inline styles have been removed in favor of CSS classes for maintainability.
  - Error and status messages use consistent, accessible styling.

---

### Checklist

- [x] The mock verification logic is successfully implemented.
- [x] The ATProto simulation logic uses the actual stored verification data.
- [x] The UI state updates correctly based on the mock data and verification state.
- [x] The verification state persists across popup sessions.
- [x] The simulate button is only enabled when the user is verified.
- [x] Tested and confirmed working on Google Chrome and Firefox.